### PR TITLE
Feat/multiple outputs

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -14,7 +14,6 @@ type Level int
 
 var (
 	debugLevel = EMERG
-	api        string
 	timeFormat string
 	fformat    = "%s:%d|%s"
 	outputs    = []io.Writer{os.Stderr}
@@ -71,8 +70,6 @@ func init() {
 	default:
 		debugLevel = ERR
 	}
-
-	api = os.Getenv("DEBUG_URL")
 
 	timeFormat = os.Getenv("DEBUG_TIME_FORMAT")
 }

--- a/logger.go
+++ b/logger.go
@@ -84,14 +84,10 @@ func llog(level Level, msg string) LogMessage {
 		buf := &bytes.Buffer{}
 		_ = json.NewEncoder(buf).Encode(m)
 		for _, out := range outputs {
-			go logWrite(buf, out)
+			go io.Copy(out, buf)
 		}
 	}
 	return m
-}
-
-func logWrite(in io.Reader, out io.Writer) {
-	io.Copy(out, in)
 }
 
 func log(level Level, fn string, line int, args ...interface{}) LogMessage {


### PR DESCRIPTION
Rewrote logger outputs as io.Writer interface, to log everywhere.

For using - add io.Writer to the list of outputs:

```
logger.AddOutput(io.Writer)
```

Example:

```
f, _ := os.Open("/tmp/log.txt")
logger.AddOutput(f)
```