### PR TITLE
Fix: multiple outputs

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,7 +1,6 @@
 package logger
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -80,11 +79,8 @@ func llog(level Level, msg string) LogMessage {
 		m.Timestamp = time.Now().Format(timeFormat)
 	}
 	if level <= debugLevel {
-		// copy log message to all outputs through bytes.Buffer
-		buf := &bytes.Buffer{}
-		_ = json.NewEncoder(buf).Encode(m)
 		for _, out := range outputs {
-			go io.Copy(out, buf)
+			_ = json.NewEncoder(out).Encode(m)
 		}
 	}
 	return m


### PR DESCRIPTION
Rewrote logger outputs as io.Writer interface, to log everywhere.

For using - add io.Writer to the list of outputs:

```
logger.AddOutput(io.Writer)
```

Example:

```
f, _ := os.OpenFile("/tmp/log.txt", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
logger.AddOutput(f)
```